### PR TITLE
Correção do nome do canal do Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Conforme [outros grupos de estudos](https://github.com/training-center/study-gro
 
 ## Como participar
 
-Basta entrar no [Slack do Training Center](https://github.com/training-center/slack) e entrar no canal **#graphql**.
+Basta entrar no [Slack do Training Center](https://github.com/training-center/slack) e entrar no canal **#graphql-studies**.
 
 ## Reuniões
 


### PR DESCRIPTION
O nome correto é graphql-studies